### PR TITLE
Avoid early loop return on instance failure

### DIFF
--- a/metasource/driver/main.go
+++ b/metasource/driver/main.go
@@ -72,7 +72,7 @@ func Database(loca string) error {
 	for _, item = range list {
 		expt = HandleRepositories(&item)
 		if expt != nil {
-			return expt
+			slog.Log(nil, slog.LevelWarn, fmt.Sprintf("[%s] Repository handling failed due to %s", item.Name, expt.Error()))
 		}
 	}
 


### PR DESCRIPTION
There can be rare times when the repodata can be generated from the active branches fetched from Bodhi. Still, the metadata might not be available after the compose creation but that does not mean that other releases do not work. This should help fix that early loop returning whenever any of the metadata fetching phases fail and allow for continuing with the others.