### PR TITLE
Arrange for publishing the project as a container image #41

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,29 @@
+LABEL maintainer "Akashdeep Dhar <t0xic0der@fedoraproject.org>"
+
+# Builder image
+
+FROM registry.fedoraproject.org/fedora-minimal:42 AS builder
+
+RUN dnf update --assumeyes && dnf install wget createrepo_c-devel gcc tar gzip golang git --assumeyes --setopt=install_weak_deps=False && dnf clean all
+
+WORKDIR /metasource
+
+COPY . .
+
+ENV CGO_ENABLED=1 GOOS=linux
+
+RUN go mod download && go build -o meta
+
+# Runtime image
+
+FROM registry.fedoraproject.org/fedora-minimal:42 as runtime
+
+RUN dnf update --assumeyes && dnf install createrepo_c-devel --assumeyes --setopt=install_weak_deps=False && dnf clean all && mkdir --parents /db
+
+VOLUME ["/db"]
+
+COPY --from=builder /metasource/meta /metasource/meta
+
+EXPOSE 8080
+
+ENTRYPOINT ["/metasource/meta"]

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,16 @@ wipe:
 	@echo "Cleaning files..."
 	@rm -f meta coverage.out index.html
 
+.PHONY: cook
+cook:
+	@echo "Building image..."
+	@podman build --security-opt label=disable --tag t0xic0der/metasource:latest .
+
+.PHONY: chow
+chow:
+	@echo "Starting container..."
+	@podman run --security-opt label=disable --publish 8080:8080 --volume /var/tmp/xyz:/db t0xic0der/metasource:latest -loglevel info -location /db dispense
+
 .PHONY: help
 help:
 	@echo "Available targets:"
@@ -39,4 +49,6 @@ help:
 	@echo "  lint - Analyze codebase"
 	@echo "  test - Run testcases"
 	@echo "  wipe - Clean files"
+	@echo "  cook - Build image"
+	@echo "  chow - Start container"
 	@echo "  help - Show documentation"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ https://metasource.gridhead.net/
 
 ## Development
 
+### Natively
+
 1.  Ensure the most recent version of `go`, `createrepo_c-devel` and `git` installed.
     ```
     $ sudo dnf install go createrepo_c-devel git --setopt=install_weak_deps=False
@@ -95,3 +97,44 @@ https://metasource.gridhead.net/
     ```
 12. Consider contributing to the project with methods that you see feasible.
 
+### Containerized
+
+1.  Ensure the most recent version of [`podman`](https://podman.io/docs/installation) is installed.
+    ```
+    $ sudo dnf install podman --setopt=install_weak_deps=False
+    ```
+2.  Clone the repository contents to your local projects directory.
+    ```
+    $ git clone https://github.com/gridhead/metasource.git
+    ```
+3.  Make the cloned repository your present working directory.
+    ```
+    $ cd metasource
+    ```
+4.  Build the image.
+    ```
+    $ podman build --security-opt label=disable --tag t0xic0der/metasource:latest .
+    ```
+5.  Populate the database.
+    ```
+    $ podman run \
+        --rm \
+        --volume="metasource_db:/db" \
+        --name="metasource" \
+        --detach metasource:latest \
+        -loglevel info \
+        -location /db \
+        database
+    ```
+6.  Execute the container.
+    ```
+    $ podman run \
+        --rm \
+        --publish="8080:8080" \
+        --volume="metasource_db:/db" \
+        --name="metasource" \
+        --detach metasource:latest \
+        -loglevel info \
+        -location /db \
+        dispense
+    ```


### PR DESCRIPTION
Hello @gridhead 👋,
I am opening this PR to address issue #41.

This PR introduces two new files and modifies one existing file, as detailed below:

## `Dockerfile`

In the Dockerfile, i added a multi-stage Dockerfile using a builder image and a runtime image to reduce the final image size.

- **Golang Installation (Manual Mode):**  
Since the official `dnf` repository only provides Golang version 1.23.x :man_shrugging:, i opted to manually install Golang version 1.24.1. This ensures we can use the required version for the project.

- **Binary Renaming:**  
  I renamed the compiled binary to `metasource-cli` to avoid accidental copying issues. 
  An incorrect name could lead to errors like:
  ```
  metasource  | Starting service in dispense mode...
  metasource  | /entrypoint.sh: line 15: ./metasource: Is a directory
  metasource exited with code 126
  ```
  
## `entrypoint.sh`

I added the `entrypoint.sh` script to handle cases where the `dispense` command is run without a provisioned database. Without a database, the server responds correctly but returns 400 errors.
```
[antoine@fedora metasource (main)]$ go build -o testbin
[antoine@fedora metasource (main)]$ mkdir tmp
[antoine@fedora metasource (main)]$ ls -l tmp/
total 0
[antoine@fedora metasource (main)]$ ./testbin -location tmp/ dispense
"GET http://127.0.0.1:8080/ HTTP/1.1" from 127.0.0.1:57766 - 200 6775B in 91.222µs
"GET http://127.0.0.1:8080/rawhide/pkg/kernel-devel HTTP/1.1" from 127.0.0.1:57766 - 400 17B in 51.59µs
"GET http://127.0.0.1:8080/rawhide/changelog/systemd-networkd HTTP/1.1" from 127.0.0.1:57766 - 400 17B in 30.28µs
```

- **Temporary Download and Copy:**  
  The script downloads the database into a temporary folder first and then copies it to the designated directory. This two-step process avoids “device or resource busy.” errors
  Example, when i try to copy on the mounted folder :
  ```
  [antoine@fedora metasource (main)]$ docker container run --volume="/tmp/metasource_db:/metasource_db" --publish="8080:8080" --name="metasource" metasource:latest
  Database not found, downloading...
  Apr 10 20:58:54.115 INF 37 repository location(s) acquired
  Apr 10 20:58:54.115 ERR unlinkat //metasource_db: device or resource busy
  ```
- **Conditional Execution:**  
  If the user already provides a database volume, the script skips the download and directly executes the `dispense` command.
  _I made this script temporarily but I think this behavior should maybe be handled by code :thinking:_

## `README.md`

Finally, i updated the `README.md` to include, step-by-step instructions on running the container with Docker.


I hope this meets your needs ! Let me know if any adjustments are required 🙏