### PR TITLE
Fix dependency requirement and version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ https://metasource.gridhead.net/
 
 ## Development
 
-1.  Ensure the most recent version of `go`, `createrepo_c-libs` and `git` installed.
+1.  Ensure the most recent version of `go`, `createrepo_c-devel` and `git` installed.
     ```
-    $ sudo dnf install go createrepo_c-libs git --install_weak_deps=False
+    $ sudo dnf install go createrepo_c-devel git --setopt=install_weak_deps=False
     ```
 2.  Clone the repository contents to your local projects directory.
     ```
@@ -32,11 +32,11 @@ https://metasource.gridhead.net/
     ```
 4.  Build the executable binary using the following command.
     ```
-    $ go build -o metasource main.go
+    $ go build -o meta main.go
     ```
 5.  View the help contents of the service's command line interface.
     ```
-    $ ./metasource --help
+    $ ./meta --help
     ```
     ```
     Usage of ./side:
@@ -46,7 +46,7 @@ https://metasource.gridhead.net/
             Set the application loglevel (default "info")
     ```
     ```
-    $ ./metasource
+    $ ./meta
     ```
     ```
     INF Expected either 'database' or 'dispense' subcommand
@@ -57,7 +57,7 @@ https://metasource.gridhead.net/
     ```
 7.  Download the databases to a temporary directory of your choice.
     ```
-    $ ./metasource -location /var/tmp/metadata database
+    $ ./meta -location /var/tmp/metadata database
     ```
 8.  Schedule the database fetching task in a periodically running cronjob.
     ```
@@ -65,7 +65,7 @@ https://metasource.gridhead.net/
     ```
 9.  Start the service backend after the database download has finished.
     ```
-    $ ./metasource -location /var/tmp/metadata dispense
+    $ ./meta -location /var/tmp/metadata dispense
     ```
 10. Access the service endpoints using the `curl` command or an internet browser.
     ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module metasource
 
-go 1.24.1
+go 1.23.7
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1


### PR DESCRIPTION
 Hey @gridhead,

While setting up this repo locally I faced below issues:
1. Flag (option) `--setopt=` was missed in the dependency installation command
    ```shell
    sdglitched@sdglitched:~/Projects/metasource$ sudo dnf install go createrepo_c-libs --install_weak_deps=False
    Unknown argument "--install_weak_deps=False" for command "install". Add "--help" for more information about the arguments.
    sdglitched@sdglitched:~/Projects/metasource$ 
    ```
2. Compatible version mismatch for `go`
    ```shell
    sdglitched@sdglitched:~/Projects/metasource$ go build -o metasource main.go
    go: go.mod requires go >= 1.24.1 (running go 1.23.7; GOTOOLCHAIN=local)
    sdglitched@sdglitched:~/Projects/metasource$ 
    ```
    I used latest stable release of Fedora-41 for which the package manager has the latest version for go: `go 1.23.7` and not `go 1.24.1`
3. Required package `createrepo_c` for building which is not available in `createrepo_c-libs`
    ```shell
    sdglitched@sdglitched:~/Projects/metasource$ go build -o metasource main.go
    go: downloading github.com/go-chi/chi/v5 v5.2.1
    go: downloading github.com/go-chi/cors v1.2.1
    go: downloading github.com/lmittmann/tint v1.0.7
    go: downloading github.com/klauspost/compress v1.18.0
    go: downloading github.com/mattn/go-sqlite3 v1.14.27
    go: downloading github.com/ulikunitz/xz v0.5.12
    # metasource/metasource/reader
    # [pkg-config --cflags  -- createrepo_c createrepo_c createrepo_c createrepo_c]
    Package createrepo_c was not found in the pkg-config search path.
    Perhaps you should add the directory containing `createrepo_c.pc' to the PKG_CONFIG_PATH environment variable
    Package 'createrepo_c' not found
    Package 'createrepo_c' not found
    Package 'createrepo_c' not found
    Package 'createrepo_c' not found
    sdglitched@sdglitched:~/Projects/metasource$
    ```
4. Naming the executable binary
    ```shell
    sdglitched@sdglitched:~/Projects/metasource$ go build -o metasource main.go
    sdglitched@sdglitched:~/Projects/metasource$ echo $?
    0
    sdglitched@sdglitched:~/Projects/metasource$ ls metasource
    config  driver  lookup  main  models  reader  routes
    sdglitched@sdglitched:~/Projects/metasource$
    ```
    In `go help build`
    ```
    The -o flag forces build to write the resulting executable or object to the named output file or directory, instead of the default behavior described in the last two paragraphs.
    If the named output is an existing directory or ends with a slash or backslash, then any resulting executables will be written to that directory.
    ```

I'm raising this PR for catering these issues.

I've applied below modifications:
1. Modified the dependency installation command in README.md to have `createrepo_c-devel` instead of `createrepo_c-libs`. Having `createrepo_c-devel` makes sure all the required dependency are available.
2. Modified the `go.mod` file to make the version of `go` compatible with the latest stable Fedora-41 (i.e., 1.23.7).
3. Modified the command to name the build binary as metaSource in README.md. This would reduce the confusion for new developers.