### PR TITLE
Strip the trailing slash (`/`) and continue routing

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		router = chi.NewRouter()
 		router.Use(middleware.Logger)
 		router.Use(middleware.Recoverer)
+		router.Use(middleware.StripSlashes)
 		router.Use(cors.Handler(cors.Options{
 			AllowedOrigins: []string{"*"},
 			AllowedMethods: []string{"GET"},


### PR DESCRIPTION
Use inbuilt function `StripSlashes` to strip the trailing slash from the URL and continue routing

![Screenshot From 2025-04-11 21-29-11](https://github.com/user-attachments/assets/83db6220-bbe2-44c4-b718-4abd57bab8a4)

Fixes: #45 