### PR TITLE
Add custom port option while starting the service

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	var expt error
-	var lglvtext, location *string
+	var lglvtext, location, port *string
 	var database, dispense *flag.FlagSet
 
 	lglvtext = flag.String("loglevel", "info", "Set the application loglevel")
@@ -27,6 +27,7 @@ func main() {
 
 	database = flag.NewFlagSet("database", flag.ExitOnError)
 	dispense = flag.NewFlagSet("dispense", flag.ExitOnError)
+	port = dispense.String("port", "8080", "Port to run the server on")
 	config.SetLogger(lglvtext)
 
 	if flag.NArg() < 1 {
@@ -74,11 +75,12 @@ func main() {
 		router.Get("/{vers}/files/{name}", routes.RetrieveFileList)
 		router.Get("/{vers}/srcpkg/{name}", routes.RetrieveSrce)
 		router.Get("/{vers}/{rela}/{name}", routes.RetrieveRelation)
-		server = &http.Server{Addr: ":8080", Handler: router}
+		server = &http.Server{Addr: ":" + *port, Handler: router}
 
 		expt = server.ListenAndServe()
 		if expt != nil {
 			slog.Log(nil, slog.LevelError, fmt.Sprintf("Error occurred. %s.", expt.Error()))
+			os.Exit(1)
 		}
 	default:
 		slog.Log(nil, slog.LevelError, "Invalid subcommand")


### PR DESCRIPTION
Add custom port option while starting the service
 - Add a custom flag in `dispence` cli to provide a custom port
 - Use that custom port to start the service
 - Exit the service if invalid port is provided

![Screenshot From 2025-04-13 14-55-44](https://github.com/user-attachments/assets/01214da4-b743-4dbf-a493-96d491deff38)
![Screenshot From 2025-04-13 14-56-34](https://github.com/user-attachments/assets/4207f983-bf06-4ecc-98c2-0e56854745ae)

Fixes: #50 