### PR TITLE
Download to a random temporary directory and perform moving on completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ https://metasource.gridhead.net/
     ```
     INF Expected either 'database' or 'dispense' subcommand
     ```
-6.  Ensure that you have at least 16GiB of storage for RPM repositories metadata.
+6.  Ensure that you have at least 10GiB of storage for RPM repositories metadata.
     ```
     $ df -h
     ```

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 			slog.Log(nil, slog.LevelError, fmt.Sprintf("%s", expt.Error()))
 			os.Exit(1)
 		}
-		expt = driver.Database(*location)
+		expt = driver.Database()
 		if expt != nil {
 			slog.Log(nil, slog.LevelError, fmt.Sprintf("%s", expt.Error()))
 			os.Exit(1)

--- a/metasource/config/base.go
+++ b/metasource/config/base.go
@@ -60,6 +60,8 @@ var FILENAME string = "metasource-%s-%s"
 
 var ATTEMPTS int64 = 4
 
+var RANDOM_LENGTH int64 = 8
+
 // SQLite3 queries for various purposes
 
 var SIGNAL_DATABASE string = "CREATE INDEX packageSource ON packages (rpm_sourcerpm)"

--- a/metasource/driver/fish.go
+++ b/metasource/driver/fish.go
@@ -7,14 +7,13 @@ import (
 	"github.com/ulikunitz/xz"
 	"io"
 	"log/slog"
-	"metasource/metasource/config"
 	"metasource/metasource/models/home"
 	"os"
 	"strings"
 	"sync"
 )
 
-func WithdrawArchives(unit *home.FileUnit, vers *string, wait *sync.WaitGroup, cast *int) {
+func WithdrawArchives(unit *home.FileUnit, vers *string, wait *sync.WaitGroup, cast *int, loca *string) {
 	defer wait.Done()
 
 	var inpt, otpt *os.File
@@ -34,7 +33,7 @@ func WithdrawArchives(unit *home.FileUnit, vers *string, wait *sync.WaitGroup, c
 	}
 	defer inpt.Close()
 
-	path = fmt.Sprintf("%s/sxml/%s", config.DBFOLDER, name)
+	path = fmt.Sprintf("%s/sxml/%s", *loca, name)
 	otpt, expt = os.Create(path)
 	if expt != nil {
 		unit.Keep = false

--- a/metasource/driver/main.go
+++ b/metasource/driver/main.go
@@ -4,55 +4,9 @@ import (
 	"fmt"
 	"log/slog"
 	"metasource/metasource/models/home"
-	"os"
 )
 
-func InitPath(loca string) error {
-	var expt error
-
-	_, expt = os.Stat(loca)
-	if os.IsNotExist(expt) {
-		expt = os.MkdirAll(loca, 0755)
-		if expt != nil {
-			return expt
-		}
-		expt = os.MkdirAll(fmt.Sprintf("%s/sxml", loca), 0755)
-		if expt != nil {
-			return expt
-		}
-		expt = os.MkdirAll(fmt.Sprintf("%s/comp", loca), 0755)
-		if expt != nil {
-			return expt
-		}
-	} else {
-		expt = os.RemoveAll(loca)
-		if expt != nil {
-			return expt
-		}
-		return InitPath(loca)
-	}
-
-	slog.Log(nil, slog.LevelWarn, "Directories initialized")
-	return nil
-}
-
-func KillTemp(loca string) error {
-	var expt error
-
-	expt = os.RemoveAll(fmt.Sprintf("%s/sxml", loca))
-	if expt != nil {
-		return expt
-	}
-	expt = os.RemoveAll(fmt.Sprintf("%s/comp", loca))
-	if expt != nil {
-		return expt
-	}
-
-	slog.Log(nil, slog.LevelWarn, "Directories removed")
-	return nil
-}
-
-func Database(loca string) error {
+func Database() error {
 	var expt error
 	var list []home.LinkUnit
 	var item home.LinkUnit
@@ -62,21 +16,11 @@ func Database(loca string) error {
 		return expt
 	}
 
-	expt = InitPath(loca)
-	if expt != nil {
-		return expt
-	}
-
 	for _, item = range list {
 		expt = HandleRepositories(&item)
 		if expt != nil {
 			slog.Log(nil, slog.LevelWarn, fmt.Sprintf("[%s] Repository handling failed due to %s", item.Name, expt.Error()))
 		}
-	}
-
-	expt = KillTemp(loca)
-	if expt != nil {
-		return expt
 	}
 
 	return nil

--- a/metasource/driver/rand.go
+++ b/metasource/driver/rand.go
@@ -1,0 +1,15 @@
+package driver
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+func GenerateIdentity(length *int64) string {
+	var randBytes []byte
+
+	randBytes = make([]byte, *length/2)
+	_, _ = rand.Read(randBytes)
+	
+	return fmt.Sprintf("%x", randBytes)
+}

--- a/metasource/driver/util.go
+++ b/metasource/driver/util.go
@@ -1,0 +1,73 @@
+package driver
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func InitPath(vers *string, loca *string) error {
+	var expt error
+
+	_, expt = os.Stat(*loca)
+	if os.IsNotExist(expt) {
+		expt = os.MkdirAll(fmt.Sprintf("%s/sxml", *loca), 0755)
+		if expt != nil {
+			return expt
+		}
+		expt = os.MkdirAll(fmt.Sprintf("%s/sxml", *loca), 0755)
+		if expt != nil {
+			return expt
+		}
+		expt = os.MkdirAll(fmt.Sprintf("%s/comp", *loca), 0755)
+		if expt != nil {
+			return expt
+		}
+	}
+
+	slog.Log(nil, slog.LevelDebug, fmt.Sprintf("[%s] Directories initialized", *vers))
+	return nil
+}
+
+func KillTemp(vers *string, loca *string) error {
+	var expt error
+
+	expt = TransferResult(vers, loca)
+	if expt != nil {
+		return expt
+	}
+
+	expt = os.RemoveAll(*loca)
+	if expt != nil {
+		return expt
+	}
+
+	slog.Log(nil, slog.LevelDebug, fmt.Sprintf("[%s] Directories removed", *vers))
+	return nil
+}
+
+func TransferResult(vers *string, loca *string) error {
+	var expt error
+	var files []os.DirEntry
+	var oldPath, newPath string
+
+	files, expt = os.ReadDir(*loca)
+	if expt != nil {
+		return expt
+	}
+
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "metasource-") && strings.HasSuffix(file.Name(), ".sqlite") {
+			oldPath = fmt.Sprintf("%s/%s", *loca, file.Name())
+			newPath = fmt.Sprintf("%s/../%s", *loca, file.Name())
+			expt = os.Rename(oldPath, newPath)
+			if expt != nil {
+				return expt
+			}
+		}
+	}
+
+	slog.Log(nil, slog.LevelDebug, fmt.Sprintf("[%s] Results transferred", *vers))
+	return nil
+}


### PR DESCRIPTION
Hey @gridhead,

Apologies for the delay! Here is the PR for fixing: #51.
I'm fairly new with `Go` and was not well at the beginning of the week.

The changes in this PR performs below crucial things:
1. Handles the creation of parent directory mentioned by user
2. Creates a hidden randomly named child directory for a repository and downloads the repository metadata and create the database in it
3. Moves the created database in the parent directory and deletes the hidden randomly named child directory for the current repository

You can test is using below commands in sequence:
```shell
$ go build -o metaSource
```
```shell
$ ./metaSource --location /tmp/metasource database
```
In a new terminal
```shell
$ watch -n 1 tree /tmp/metasource
```

Attaching a short clip of the complete walk-through (watch till the end :smile_cat:)
https://github.com/user-attachments/assets/dfb0ea7f-f726-4b4c-987c-93f986d5c798

Fell free to let me know if any changes are needed.