### PR TITLE
chore: updated doc with description of metasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ o888o o888o o888o `Y8bod8P'   "888" `Y888""8o 8""888P' `Y8bod8P'  `V88V"V8P' d88
 Performant source for RPM repositories metadata                                                    v0.1.0
 ```
 
+MetaSource is a performant source for RPM repositories metadata which has an access to the metadata of the different Fedora Linux package repositories and will serve you the most recent information available. It will parse through the "updates-testing" repository before moving onto the likes of "updates" and "releases" repository if no information is found in the previous repository.
+
+Utilize the fast lookup interface to acquaint yourself with the API endpoints and expected outputs. Press `ENTER` after typing the name to execute a lookup in a new window. If you query for a non-existent branch - it will return an **HTTP 400** error. If you query for a non-existent package - it will return an **HTTP 404** error. Please report persistent **HTTP 500** errors to the [Fedora Infrastructure](https://pagure.io/fedora-infrastructure/issues) team.
+
 ## Deployment
 
 https://metasource.gridhead.net/


### PR DESCRIPTION
which link should I use for the "Fedora Infrastructure Team" in the text?
it should be easy if someone wants to report an issue...

or should we just leave it out?

also, if there's anything that needs to be changed, please let me know

Fixes #68 